### PR TITLE
Added 'MeasureAxisViewport'

### DIFF
--- a/lib/commons/axis.dart
+++ b/lib/commons/axis.dart
@@ -82,6 +82,9 @@ class MeasureAxis {
   /// format text label to show
   final MeasureFormat? labelFormat;
 
+  /// Set the viewport of the measure axis
+  final NumericViewport? numericViewport;
+
   const MeasureAxis({
     this.showLine = false,
     this.lineStyle = const LineStyle(),
@@ -93,5 +96,6 @@ class MeasureAxis {
     this.desiredMaxTickCount,
     this.desiredMinTickCount,
     this.desiredTickCount,
+    this.numericViewport,
   });
 }

--- a/lib/numeric/combo.dart
+++ b/lib/numeric/combo.dart
@@ -184,6 +184,12 @@ class DChartComboN extends StatelessWidget {
       primaryMeasureAxis: measureAxis == null
           ? null
           : common.NumericAxisSpec(
+              viewport: measureAxis!.numericViewport == null ?
+                  null :
+                  charts.NumericExtents(
+                    measureAxis!.numericViewport!.min,
+                    measureAxis!.numericViewport!.max,
+                  ),
               renderSpec: common.SmallTickRendererSpec(
                 axisLineStyle: measureAxis?.lineStyle.getRender(),
                 labelStyle: measureAxis?.labelStyle.getRender(),

--- a/lib/numeric/line.dart
+++ b/lib/numeric/line.dart
@@ -167,6 +167,12 @@ class DChartLineN extends StatelessWidget {
       primaryMeasureAxis: measureAxis == null
           ? null
           : common.NumericAxisSpec(
+              viewport: measureAxis!.numericViewport == null ?
+                  null :
+                  charts.NumericExtents(
+                    measureAxis!.numericViewport!.min,
+                    measureAxis!.numericViewport!.max,
+                  ),
               renderSpec: common.SmallTickRendererSpec(
                 axisLineStyle: measureAxis?.lineStyle.getRender(),
                 labelStyle: measureAxis?.labelStyle.getRender(),

--- a/lib/numeric/scatter.dart
+++ b/lib/numeric/scatter.dart
@@ -167,6 +167,12 @@ class DChartScatterN extends StatelessWidget {
       primaryMeasureAxis: measureAxis == null
           ? null
           : common.NumericAxisSpec(
+              viewport: measureAxis!.numericViewport == null ?
+                  null :
+                  charts.NumericExtents(
+                    measureAxis!.numericViewport!.min,
+                    measureAxis!.numericViewport!.max,
+                  ),
               renderSpec: common.SmallTickRendererSpec(
                 axisLineStyle: measureAxis?.lineStyle.getRender(),
                 labelStyle: measureAxis?.labelStyle.getRender(),

--- a/lib/ordinal/bar.dart
+++ b/lib/ordinal/bar.dart
@@ -176,6 +176,12 @@ class DChartBarO extends StatelessWidget {
       primaryMeasureAxis: measureAxis == null
           ? null
           : common.NumericAxisSpec(
+              viewport: measureAxis!.numericViewport == null ?
+                  null :
+                  charts.NumericExtents(
+                    measureAxis!.numericViewport!.min,
+                    measureAxis!.numericViewport!.max,
+                  ),
               renderSpec: common.SmallTickRendererSpec(
                 axisLineStyle: measureAxis?.lineStyle.getRender(),
                 labelStyle: measureAxis?.labelStyle.getRender(),

--- a/lib/ordinal/combo.dart
+++ b/lib/ordinal/combo.dart
@@ -184,6 +184,12 @@ class DChartComboO extends StatelessWidget {
       primaryMeasureAxis: measureAxis == null
           ? null
           : common.NumericAxisSpec(
+              viewport: measureAxis!.numericViewport == null ?
+                  null :
+                  charts.NumericExtents(
+                    measureAxis!.numericViewport!.min,
+                    measureAxis!.numericViewport!.max,
+                  ),
               renderSpec: common.SmallTickRendererSpec(
                 axisLineStyle: measureAxis?.lineStyle.getRender(),
                 labelStyle: measureAxis?.labelStyle.getRender(),

--- a/lib/time/bar.dart
+++ b/lib/time/bar.dart
@@ -175,6 +175,12 @@ class DChartBarT extends StatelessWidget {
       primaryMeasureAxis: measureAxis == null
           ? null
           : common.NumericAxisSpec(
+              viewport: measureAxis!.numericViewport == null ?
+                  null :
+                  charts.NumericExtents(
+                    measureAxis!.numericViewport!.min,
+                    measureAxis!.numericViewport!.max,
+                  ),
               renderSpec: common.SmallTickRendererSpec(
                 axisLineStyle: measureAxis?.lineStyle.getRender(),
                 labelStyle: measureAxis?.labelStyle.getRender(),

--- a/lib/time/combo.dart
+++ b/lib/time/combo.dart
@@ -193,6 +193,12 @@ class DChartComboT extends StatelessWidget {
       primaryMeasureAxis: measureAxis == null
           ? null
           : common.NumericAxisSpec(
+              viewport: measureAxis!.numericViewport == null ?
+                  null :
+                  charts.NumericExtents(
+                    measureAxis!.numericViewport!.min,
+                    measureAxis!.numericViewport!.max,
+                  ),
               renderSpec: common.SmallTickRendererSpec(
                 axisLineStyle: measureAxis?.lineStyle.getRender(),
                 labelStyle: measureAxis?.labelStyle.getRender(),

--- a/lib/time/line.dart
+++ b/lib/time/line.dart
@@ -172,6 +172,12 @@ class DChartLineT extends StatelessWidget {
       primaryMeasureAxis: measureAxis == null
           ? null
           : common.NumericAxisSpec(
+              viewport: measureAxis!.numericViewport == null ?
+                  null :
+                  charts.NumericExtents(
+                    measureAxis!.numericViewport!.min,
+                    measureAxis!.numericViewport!.max,
+                  ),
               renderSpec: common.SmallTickRendererSpec(
                 axisLineStyle: measureAxis?.lineStyle.getRender(),
                 labelStyle: measureAxis?.labelStyle.getRender(),

--- a/lib/time/scatter.dart
+++ b/lib/time/scatter.dart
@@ -172,6 +172,12 @@ class DChartScatterT extends StatelessWidget {
       primaryMeasureAxis: measureAxis == null
           ? null
           : common.NumericAxisSpec(
+              viewport: measureAxis!.numericViewport == null ?
+                  null :
+                  charts.NumericExtents(
+                    measureAxis!.numericViewport!.min,
+                    measureAxis!.numericViewport!.max,
+                  ),
               renderSpec: common.SmallTickRendererSpec(
                 axisLineStyle: measureAxis?.lineStyle.getRender(),
                 labelStyle: measureAxis?.labelStyle.getRender(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   community_charts_common:
     dependency: "direct main"
     description:
@@ -83,30 +83,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -132,10 +124,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -172,10 +164,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -184,6 +176,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=2.5.0"


### PR DESCRIPTION
Tried to implement #19. Got this far. 

Especially tested on the `DChartBarO` Widget.

Theres only a condition, that `measureAxis!.numericViewport!.min` must be `0` so that the bar is correctly painted. If `measureAxis!.numericViewport!.min > 0` the bar will be painted above the measure axis. If `measureAxis!.numericViewport!.min < 0` there is not painted space between the bar and the measure axis.

I also think the `desiredTickCount` attributes get ignored.

I guess it's a bug caused by the *community_charts* plugin, but im not sure. Anyway I am unfortunately not able to solve this bug, though I would look forward, that this issue will resolve. 