### PR TITLE
fix: Supplement the document of thickLength property in DomainAxis class

### DIFF
--- a/lib/commons/axis.dart
+++ b/lib/commons/axis.dart
@@ -32,6 +32,10 @@ class DomainAxis extends ChartAxis {
 
   /// thick axis length\
   /// default: 3
+  ///
+  /// If thickLength > 0, the line is displayed on the left
+  ///
+  /// if thickLength < 0, the line will be displayed on the right
   final int thickLength;
 
   /// set limit view for domain axis


### PR DESCRIPTION
I am unable to customize the y-axis and add a horizontal reference line to the right of the y-axis at the same time by reading the provided documents. Through testing, I found that when thickLength is negative, it can be successfully added to the right of the y-axis.
